### PR TITLE
Adding note about Manifest v3

### DIFF
--- a/adblock-list.txt
+++ b/adblock-list.txt
@@ -2,8 +2,8 @@
 ! Homepage: http://www.spam404.com/
 ! Title: Spam404
 ! Expires: 2 days
-! Version: 6768
-! Last modified: 28 May 2019
+! Version: 6769
+! Last modified: 30 May 2019
 ! Description: This filter protects you from online scams. This filter is regularly updated with data collected by Spam404.com.
 !
 ! You can report unblocked content and direct general queries to us
@@ -11,6 +11,7 @@
 !
 ! License: https://github.com/Spam404/lists/blob/master/LICENSE.md/LICENSE.md
 !         
+! IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS: Our list does not, can not, and will never ever support Manifest v3, due to its laughably short rule limit and the removal of advanced syntaxes. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
 !
 !-_-_-_-_-_-_-_-External Link Survey Scams-_-_-_-_-_-_-_-!
 ##[href^="http://cleanfiles.net/"]

--- a/adblock-list.txt
+++ b/adblock-list.txt
@@ -11,7 +11,7 @@
 !
 ! License: https://github.com/Spam404/lists/blob/master/LICENSE.md/LICENSE.md
 !         
-! IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS: Our list does not, can not, and will never ever support Manifest v3, due to its laughably short rule limit and the removal of advanced syntaxes. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
+! IMPORTANT NOTE FOR CHROMIUM-BROWSER USERS: Our list does not, can not, and will not support Manifest v3 insofar as it is currently shaped, due to its laughably short rule limit and the removal of advanced syntaxes. Issue reports for Manifest v3-based extension versions will not be accepted, and if you do submit one, you would be asked to use an alternate web browser or web browser version instead.
 !
 !-_-_-_-_-_-_-_-External Link Survey Scams-_-_-_-_-_-_-_-!
 ##[href^="http://cleanfiles.net/"]


### PR DESCRIPTION
Greetings, Dandelion Sprout here, the maintainer of *Dandelion Sprout's Nordic Filters* and an adblocker enthusiast in general.

So it seems that the Chromium team [has decided to follow through with their war on adblockers](https://9to5google.com/2019/05/29/chrome-ad-blocking-enterprise-manifest-v3/), by having a laughably small current rule limit of 35,000 and by removing most of the more advanced syntaxes that recent adblocker versions can use from October-ish onwards. So tonight I've decided to venture a bit around on the GitHub issue trackers of various lists that are included in adblockers, and get them to publicly take a stance against Manifest v3, in order to educate laymen and to establish *some* kind of pressure on the Chromium team.

Seeing as their current limit on non-included rules is only 5,000, Manifest v3 would prevent users of soon-to-be-current-version Chromium browsers from loading your list as all, as it currently stands.

I've turned on the ability for maintainers to edit this pull, should you guys want to do any changes to the note's text on your own.